### PR TITLE
Use node 18 intead of node 20

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:20-slim AS base
+FROM node:18-slim AS base
 ENV PNPM_HOME="/pnpm"
 ENV PATH="$PNPM_HOME:$PATH"
 RUN corepack enable


### PR DESCRIPTION
It seems like there's a bug with the node-postgres library when running in Node 20 that leads to SSL errors:

https://github.com/MatteoGioioso/serverless-pg/issues/91

Node 18 seems to always work fine though 👍