### PR TITLE
Stop exposing Redis port

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -17,8 +17,6 @@ services:
 
   redis:
     image: redis:7.2.4
-    ports:
-      - 6379:6379
     restart: on-failure
 
   otel-collector:


### PR DESCRIPTION
Exposing the Redis port (especially with a Redis instance that doesn't have a password) makes is possible for anyone to read and write to the Redis DB.

We should limit the access to the internal Docker network instead.