### PR TITLE
Store snapshots of pg stat statements in a clickhouse table

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,4 +27,4 @@ RUN pnpm run build
 FROM base
 COPY --from=build /app /app
 EXPOSE 3000
-CMD [ "pnpm", "start_with_data_init" ]
+CMD [ "pnpm", "start-with-data-init" ]

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "start": "next start",
     "start-worker-pm2": "pm2 start --interpreter bun scripts/tracedQueriesGeneratorStart.ts",
     "postinstall": "npx prisma generate",
-    "start_with_data_init": "npx prisma migrate deploy && npx ts-node -T prisma/initData.ts && npm run start"
+    "start-with-data-init": "npx prisma migrate deploy && npx ts-node -T prisma/initData.ts && npm run start",
+    "data-init": "npx prisma migrate deploy && npx ts-node -T prisma/initData.ts"
   },
   "version": "0.1.0",
   "dependencies": {
@@ -38,18 +39,19 @@
     "next-auth": "^4.24.7",
     "pm2": "^5.3.1",
     "postgres": "^3.4.4",
+    "prisma": "^5.15.0",
     "prismjs": "^1.29.0",
     "react": "^18.3.1",
     "react-dom": "18.3.1",
     "react-hook-form": "^7.52.0",
     "react-hot-toast": "^2.4.1",
+    "superjson": "^2.2.1",
     "tailwind-merge": "^2.3.0",
     "tailwindcss": "^3.0.12",
     "tailwindcss-animate": "^1.0.7",
     "typeface-merriweather": "^1.1.13",
     "vitest": "^0.33.0",
-    "zod": "^3.22.4",
-    "prisma": "^5.15.0"
+    "zod": "^3.22.4"
   },
   "devDependencies": {
     "@types/lodash": "^4.14.195",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -104,6 +104,9 @@ dependencies:
   react-hot-toast:
     specifier: ^2.4.1
     version: 2.4.1(csstype@3.1.3)(react-dom@18.3.1)(react@18.3.1)
+  superjson:
+    specifier: ^2.2.1
+    version: 2.2.1
   tailwind-merge:
     specifier: ^2.3.0
     version: 2.3.0
@@ -1313,6 +1316,13 @@ packages:
     engines: {node: '>= 0.6'}
     dev: false
 
+  /copy-anything@3.0.5:
+    resolution: {integrity: sha512-yCEafptTtb4bk7GLEQoM8KVJpxAfdBJYaXyzQEgQQQgYrZiDp8SJmGKlYza6CYjEDNstAdNdKA3UuoULlEbS6w==}
+    engines: {node: '>=12.13'}
+    dependencies:
+      is-what: 4.1.16
+    dev: false
+
   /create-require@1.1.1:
     resolution: {integrity: sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==}
 
@@ -1818,6 +1828,11 @@ packages:
   /is-number@7.0.0:
     resolution: {integrity: sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==}
     engines: {node: '>=0.12.0'}
+    dev: false
+
+  /is-what@4.1.16:
+    resolution: {integrity: sha512-ZhMwEosbFJkA0YhFnNDgTM4ZxDRsS6HqTo7qsZM08fehyRYIYa0yHu5R6mgo1n/8MgaPBXiPimPD77baVFYg+A==}
+    engines: {node: '>=12.13'}
     dev: false
 
   /isexe@2.0.0:
@@ -2896,6 +2911,13 @@ packages:
       mz: 2.7.0
       pirates: 4.0.6
       ts-interface-checker: 0.1.13
+    dev: false
+
+  /superjson@2.2.1:
+    resolution: {integrity: sha512-8iGv75BYOa0xRJHK5vRLEjE2H/i4lulTjzpUXic3Eg8akftYjkmQDa8JARQ42rlczXyFR3IeRoeFCc7RxHsYZA==}
+    engines: {node: '>=16'}
+    dependencies:
+      copy-anything: 3.0.5
     dev: false
 
   /supports-color@7.2.0:

--- a/prisma/initAndMigrateClickhouse.ts
+++ b/prisma/initAndMigrateClickhouse.ts
@@ -1,0 +1,34 @@
+import { clickhouseClient } from "../src/utils/insight/clickhouse";
+import { createTracedQueriesTableIfNotExists } from "../src/utils/insight/createTracedQueriesTable";
+
+export const initAndMigrateClickhouse = async () => {
+  await createTracedQueriesTableIfNotExists();
+
+  // delete table if exists pg_stat_statements_snapshots
+  await clickhouseClient.query({
+    query: `
+			DROP TABLE IF EXISTS pg_stat_statements_snapshots;
+		`,
+  });
+
+  await clickhouseClient.query({
+    query: `
+		CREATE TABLE IF NOT EXISTS pg_stat_statements_snapshots (
+			queryid String,
+			query String,
+			calls UInt32,
+			total_exec_time Float64,
+			min_exec_time Float64,
+			max_exec_time Float64,
+			mean_exec_time Float64,
+			stddev_exec_time Float64,
+			percentageOfLoad Float64,
+			timestamp Timestamp,
+			pgInstanceUuid String
+		) ENGINE = MergeTree()
+		ORDER BY
+			(timestamp, queryid)
+		TTL timestamp + INTERVAL 1 DAY;
+		`,
+  });
+};

--- a/prisma/initData.ts
+++ b/prisma/initData.ts
@@ -2,11 +2,14 @@ import { PrismaClient } from "@prisma/client";
 import { writeFileSync, existsSync } from "fs";
 import { randomBytes } from "crypto";
 import { getEnv } from "@larskarbo/get-env";
+import { initAndMigrateClickhouse } from "./initAndMigrateClickhouse";
 
 const prisma = new PrismaClient();
 
 async function main() {
   console.log(`Start seeding with initial data...`);
+
+	await initAndMigrateClickhouse();
 
   const passwordEncryptionSecretFile = getEnv(
     "PASSWORD_ENCRYPTION_SECRET_FILE"

--- a/src/pages/dashboard/index.tsx
+++ b/src/pages/dashboard/index.tsx
@@ -5,6 +5,7 @@ import Layout from "../../components/layout/Layout";
 import { QueryRow } from "../../components/QueryRow";
 import { Spinner } from "../../components/Spinner";
 import { trpc } from "../../utils/trpc";
+import { formatDistanceToNow } from "date-fns";
 
 export const Project = () => {
   const [instanceUuid, setInstanceUuid] = useState<string | null>(null);
@@ -42,6 +43,7 @@ export const Project = () => {
     });
 
   const queries = data?.queries;
+  const lastReset = data?.lastReset;
 
   const pgInstances = me?.Team?.Projects[0]?.PgInstances;
 
@@ -62,32 +64,43 @@ export const Project = () => {
               ))}
             </select>
           </div>
-          <div className="flex gap-4 mb-8">
-            <Button
-              onClick={() => {
-                if (!instanceUuid) {
-                  return;
-                }
-
-                void resetPgStats({
-                  instanceUuid: instanceUuid,
-                });
-              }}
-              className="border hover:bg-gray-100 text-gray-900 px-4 py-2 rounded-md text-xs disabled:opacity-50"
-              disabled={isResettingPgStats}
-            >
-              {isResettingPgStats ? "Resetting..." : "Reset pg stats"}
-            </Button>
-            <Button
-              onClick={() => {
-                void refetch();
-              }}
-              className="border hover:bg-gray-100 text-gray-900 px-4 py-2 rounded-md text-xs disabled:opacity-50"
-              disabled={isFetching || isResettingPgStats}
-            >
-              Refresh
-              {isFetching && "ing..."}
-            </Button>
+          <div className="mb-8">
+            <div className="flex gap-4">
+              <div>
+                <Button
+                  onClick={() => {
+                    if (!instanceUuid) {
+                      return;
+                    }
+                    void resetPgStats({
+                      instanceUuid: instanceUuid,
+                    });
+                  }}
+                  className="border hover:bg-gray-100 text-gray-900 px-4 py-2 rounded-md text-xs disabled:opacity-50"
+                  disabled={isResettingPgStats}
+                >
+                  {isResettingPgStats ? "Resetting..." : "Reset pg stats"}
+                </Button>
+              </div>
+              <Button
+                onClick={() => {
+                  void refetch();
+                }}
+                className="border hover:bg-gray-100 text-gray-900 px-4 py-2 rounded-md text-xs disabled:opacity-50"
+                disabled={isFetching || isResettingPgStats}
+              >
+                Refresh
+                {isFetching && "ing..."}
+              </Button>
+            </div>
+            {lastReset && (
+              <div className="text-xxs text-gray-500 mt-1">
+                Last reset:{" "}
+                {formatDistanceToNow(new Date(lastReset), {
+                  addSuffix: true,
+                })}
+              </div>
+            )}
           </div>
 
           {isLoading ? (
@@ -113,7 +126,7 @@ export const Project = () => {
                       Total duration
                     </th>
                     <th className="py-2 pr-2 font-normal text-xxs whitespace-nowrap">
-                      Requests
+                      Calls
                     </th>
                     <th className="py-2 pr-2 font-normal text-xxs whitespace-nowrap ">
                       Prisma

--- a/src/pages/dashboard/setup/pg-instance/[pgUuid].tsx
+++ b/src/pages/dashboard/setup/pg-instance/[pgUuid].tsx
@@ -103,8 +103,21 @@ const NewPostgresInstanceForm = ({ pgUuid }: { pgUuid: string }) => {
         router.push("/dashboard/setup");
       },
     });
+
   const { mutate: updatePgInstance, isLoading: isUpdatingPgInstance } =
-    trpc.setup.updatePgInstance.useMutation();
+    trpc.setup.updatePgInstance.useMutation({
+      onSuccess: () => {
+        router.push("/dashboard/setup");
+      },
+    });
+
+  const { mutate: deletePgInstance, isLoading: isDeletingPgInstance } =
+    trpc.setup.deletePgInstance.useMutation({
+      onSuccess: () => {
+        router.push("/dashboard/setup");
+      },
+    });
+
   const {
     data: testResult,
     mutate: testPgConnection,
@@ -326,17 +339,34 @@ const NewPostgresInstanceForm = ({ pgUuid }: { pgUuid: string }) => {
 
       <div className="flex space-x-4 mt-8">
         {pgInstance ? (
-          <Button
-            onClick={() => {
-              updatePgInstance({
-                instance: workingPginstace,
-                uuid: pgInstance.uuid,
-              });
-            }}
-            isLoading={isUpdatingPgInstance}
-          >
-            Update instance
-          </Button>
+          <>
+            <Button
+              onClick={() => {
+                updatePgInstance({
+                  instance: workingPginstace,
+                  uuid: pgInstance.uuid,
+                });
+              }}
+              isLoading={isUpdatingPgInstance}
+            >
+              Update instance
+            </Button>
+            <Button
+              onClick={() => {
+                const confirm = window.confirm(
+                  "Are you sure you want to delete this instance?"
+                );
+                if (confirm) {
+                  deletePgInstance({
+                    uuid: pgInstance.uuid,
+                  });
+                }
+              }}
+              isLoading={isDeletingPgInstance}
+            >
+              Delete instance
+            </Button>
+          </>
         ) : (
           <Button
             onClick={() => {

--- a/src/server/routers/setup.ts
+++ b/src/server/routers/setup.ts
@@ -205,6 +205,31 @@ export const setupRouter = router({
       });
     }),
 
+  deletePgInstance: procedure
+    .input(z.object({ uuid: z.string() }))
+    .mutation(async ({ input, ctx }) => {
+      const { uuid } = input;
+      const { user } = ctx;
+
+      const pgInstance = await prisma.pgInstance.findUniqueOrThrow({
+        where: {
+          uuid,
+        },
+      });
+
+      await ensureUserHasAccessToProject({
+        prisma,
+        user,
+        projectId: pgInstance.projectId,
+      });
+
+      return await prisma.pgInstance.delete({
+        where: {
+          uuid,
+        },
+      });
+    }),
+
   clickhouseStatus: procedure.query(async () => {
     const simpleQuery = `
 			SELECT 1;

--- a/src/server/snapshot/savePgQuerySnapshot.ts
+++ b/src/server/snapshot/savePgQuerySnapshot.ts
@@ -1,0 +1,23 @@
+import { clickhouseClient } from "../../utils/insight/clickhouse";
+import { PgRow } from "../../utils/insight/pgStatQueries";
+
+export const savePgQuerySnapshot = async ({
+  pgRows,
+  pgInstanceUuid,
+}: {
+  pgRows: PgRow[];
+  pgInstanceUuid: string;
+}) => {
+  clickhouseClient.insert({
+    table: "pg_stat_statements_snapshots",
+    values: pgRows.map((row) => ({
+      ...row,
+      timestamp: new Date(),
+      pgInstanceUuid,
+    })),
+    format: "JSONEachRow",
+    clickhouse_settings: {
+      async_insert: 1,
+    },
+  });
+};

--- a/src/server/snapshot/snapshottedQuery.ts
+++ b/src/server/snapshot/snapshottedQuery.ts
@@ -1,0 +1,13 @@
+export type SnapshottedQuery = {
+  queryid: string;
+  query: string;
+  calls: number;
+  total_exec_time: number;
+  min_exec_time: number;
+  max_exec_time: number;
+  mean_exec_time: number;
+  stddev_exec_time: number;
+  percentageOfLoad: number;
+  timestamp: string;
+  pgInstanceUuid: string;
+};

--- a/src/server/trpc.ts
+++ b/src/server/trpc.ts
@@ -1,5 +1,6 @@
 import { initTRPC } from "@trpc/server";
 import { Context } from "./context";
+import superjson from "superjson";
 
 const t = initTRPC.context<Context>().create({
   errorFormatter({ error, shape }) {
@@ -13,6 +14,7 @@ const t = initTRPC.context<Context>().create({
 
     return shape;
   },
+  transformer: superjson,
 });
 
 // Base router and procedure helpers

--- a/src/utils/insight/pgStatQueries.ts
+++ b/src/utils/insight/pgStatQueries.ts
@@ -11,6 +11,7 @@ export type PgRow = {
   mean_exec_time: number;
   stddev_exec_time: number;
   percentageOfLoad: number;
+  timestamp: Date;
 };
 
 export const getTopPgQueries = async (
@@ -54,12 +55,15 @@ export const getTopPgQueries = async (
     resultPromise,
   ]);
 
-  return result.map((row) => {
+  const pgRows: PgRow[] = result.map((row) => {
     return {
       ...row,
       percentageOfLoad: round((row.total_exec_time / totalExecTime) * 100, 2),
+      timestamp: new Date(),
     };
   });
+
+  return pgRows;
 };
 
 export const getTotalExecTime = async (postgres: postgres.Sql<{}>) => {

--- a/src/utils/trpc.ts
+++ b/src/utils/trpc.ts
@@ -4,6 +4,7 @@ import type { AppRouter } from "../server/routers/router";
 import { isDev } from "../env";
 import { getErrorMessage } from "../components/utils";
 import toast from "react-hot-toast";
+import superjson from "superjson";
 
 function getBaseUrl() {
   if (typeof window !== "undefined")
@@ -60,6 +61,7 @@ export const trpc = createTRPCNext<AppRouter>({
           },
         },
       },
+      transformer: superjson,
     };
   },
   /**

--- a/worker.Dockerfile
+++ b/worker.Dockerfile
@@ -18,5 +18,3 @@ COPY scripts ./scripts
 COPY next-env.d.ts ./
 
 RUN pnpx prisma generate
-
-CMD [ "bun", "run", "scripts/tracedQueriesGeneratorStart.ts" ]


### PR DESCRIPTION
This PR adds a new clickhouse table `pg_stat_statements_snapshots` that can store snapshots of pg stat statements. This can be useful in the future to show graphs etc...

Also includes various smaller improvements